### PR TITLE
issue4: uses HashSet to prevent duplicated SettingValues

### DIFF
--- a/SettingUtil.cs
+++ b/SettingUtil.cs
@@ -69,11 +69,17 @@ namespace falcon.cmtracker
             }
         }
         public event PropertyChangedEventHandler PropertyChanged;
+
+        //Overriten so combination of account+boss is used to ensure uniqueness in HashSets
+        public override int GetHashCode()
+        {
+            return (_account.GetHashCode() * 397) ^ _boss.GetHashCode();
+        }
     }
 
     class SettingUtil : INotifyPropertyChanged
     {
-        private List<SettingValue> Setting = new List<SettingValue>();
+        private HashSet<SettingValue> Setting = new HashSet<SettingValue>();
         private string _localSettingValue = "";
         public string SettingString
         {
@@ -125,10 +131,10 @@ namespace falcon.cmtracker
                     break;
                 }
             }
-            this.SettingString = ConvirtListToString(this.Setting);
+            this.SettingString = ConvertHashToString(this.Setting);
         }
 
-        public String ConvirtListToString(List<SettingValue> arrayValues)
+        public String ConvertHashToString(HashSet<SettingValue> arrayValues)
         {
             var localValue = "";
             foreach (SettingValue Item in arrayValues)
@@ -180,7 +186,7 @@ namespace falcon.cmtracker
             {
                 this.Setting.Add(new SettingValue(accountName, boss, false));
             }
-            this.SettingString = ConvirtListToString(this.Setting);
+            this.SettingString = ConvertHashToString(this.Setting);
 
         }
 
@@ -207,7 +213,7 @@ namespace falcon.cmtracker
             {
                 Item.Value = false;
             }
-            this.SettingString = ConvirtListToString(this.Setting);
+            this.SettingString = ConvertHashToString(this.Setting);
         }
     }
 }

--- a/SettingUtil.cs
+++ b/SettingUtil.cs
@@ -69,17 +69,11 @@ namespace falcon.cmtracker
             }
         }
         public event PropertyChangedEventHandler PropertyChanged;
-
-        //Overriten so combination of account+boss is used to ensure uniqueness in HashSets
-        public override int GetHashCode()
-        {
-            return (_account.GetHashCode() * 397) ^ _boss.GetHashCode();
-        }
     }
 
     class SettingUtil : INotifyPropertyChanged
     {
-        private HashSet<SettingValue> Setting = new HashSet<SettingValue>();
+        private HashSet<SettingValue> Setting = new HashSet<SettingValue>(new SettingValueComparer());
         private string _localSettingValue = "";
         public string SettingString
         {

--- a/SettingValueComparer.cs
+++ b/SettingValueComparer.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace falcon.cmtracker
+{
+    public class SettingValueComparer : IEqualityComparer<SettingValue>
+    {
+        public bool Equals(SettingValue x, SettingValue y)
+        {
+            return x.Account.Equals(y.Account) && x.Boss.Equals(y.Boss); 
+        }
+
+        public int GetHashCode(SettingValue obj)
+        {
+            return (obj.Account.GetHashCode() * 397) + obj.Boss.GetHashCode();
+        }
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "CM Tracker",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "namespace": "falcon.cmtracker",
   "package": "CM Tracker.dll",
   "manifest_version": "1",
@@ -23,7 +23,7 @@
   "api_permissions": {
     "account": {
       "optional": true,
-      "details": "This will be shown as an option to set different CM cleats for each account you have"
+      "details": "This will be shown as an option to set different CM clears for each account you have"
     }
   }
 }


### PR DESCRIPTION
Uses a `HashSet` instead of `List` to keep track of `SettingValue` and avoid duplicates of settings using both account+boss as key. 