### PR TITLE
Automatically clears bosses after weekly reset

### DIFF
--- a/UnixTimestampHelper.cs
+++ b/UnixTimestampHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace falcon.cmtracker
+{
+
+    public class UnixTimestampHelper
+    {
+        public static long getLatestWeeklyServerResetTimestampInSeconds()
+        {            
+            DateTimeOffset nowUtc = DateTimeOffset.UtcNow;       
+
+            int daysSinceMonday = (int)nowUtc.DayOfWeek - (int)DayOfWeek.Monday;
+            //Adjust if current day is Sunday
+            if (daysSinceMonday < 0)
+            {                
+                daysSinceMonday = 7;
+            }
+            DateTimeOffset latestMondayUtc = nowUtc.AddDays(-daysSinceMonday);
+
+            TimeSpan utcMinus6Offset = TimeSpan.FromHours(-6);
+
+            /** Set the time to weekly reset (01:30:00) of the latest Monday in UTC-6
+             * as documented in https://wiki.guildwars2.com/wiki/Server_reset#Weekly_reset.
+             */
+            DateTimeOffset latestMondayUtcMinus6 = new DateTimeOffset(
+                latestMondayUtc.Year,
+                latestMondayUtc.Month,
+                latestMondayUtc.Day,
+                1, 30, 0, 
+                utcMinus6Offset);
+            
+            return latestMondayUtcMinus6.ToUnixTimeSeconds();
+        }
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "CM Tracker",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "namespace": "falcon.cmtracker",
   "package": "CM Tracker.dll",
   "manifest_version": "1",


### PR DESCRIPTION
Allows the module to automatically reset boss clears after weekly reset, which is defined by[ the wiki](https://wiki.guildwars2.com/wiki/Server_reset#Weekly_reset) on each Monday at 01:30:00 UTC-6. 

## New properties
Two new properties were defined:

- `SHOULD_AUTOMATICALLY_RESET_CLEARS`: this is a user available setting so they can decide to disable this functionality. It will be turned on by default. 
- `LAST_WEEKLY_RESET_TIMESTAMP_IN_SECONDS `: internal property that keeps track of the latest weekly reset.

On startup if the module detects the latest weekly reset is older than the one stored, then it will proceed to do the cleanup if the user has it enabled. 